### PR TITLE
Updated Dev Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "postbuild": "node postbuild.js"
   },
   "devDependencies": {
-    "archiver": "^2.0.0",
-    "babel-core": "^6.25.0",
-    "babel-loader": "^7.1.1",
-    "babel-preset-env": "^1.6.0",
-    "css-loader": "^0.28.4",
-    "extract-text-webpack-plugin": "^3.0.0",
+    "archiver": "^2.1.1",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-preset-env": "^1.7.0",
+    "css-loader": "^0.28.11",
+    "extract-text-webpack-plugin": "^3.0.2",
     "html-webpack-inline-source-plugin": "^0.0.9",
-    "html-webpack-plugin": "^2.29.0",
+    "html-webpack-plugin": "^2.30.1",
     "style-loader": "^0.18.2",
-    "webpack": "^3.3.0",
-    "webpack-dev-server": "^2.5.1"
+    "webpack": "^3.12.0",
+    "webpack-dev-server": "^2.11.2"
   }
 }


### PR DESCRIPTION
Updated the dev dependencies and confirmed `npm start` and `npm run build` still function as expected